### PR TITLE
Feature/7 pci msi vec count does not exist in the kernel 3

### DIFF
--- a/pciedev_probe_exp.c
+++ b/pciedev_probe_exp.c
@@ -296,7 +296,7 @@ int    pciedev_probe_exp(struct pci_dev *dev, const struct pci_device_id *id,
     /*******PREPARE INTERRUPTS******/
     
     pciedev_cdev_p->pciedev_dev_m[m_brdNum]->irq_flag = IRQF_SHARED ;
-    #ifdef CONFIG_PCI_MSI
+    #if defined(CONFIG_PCI_MSI) && ( LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0) )
    tmp_msi_num = pci_msi_vec_count(dev);
    printk(KERN_ALERT "MSI COUNT %i\n", tmp_msi_num);
    


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22635214/124136870-7433f600-da85-11eb-88ff-adf580f35ff7.png)


I could not find function `pci_msi_vec_count` for kernel version `3.13.0-24-generic`. For time being config PCI MSI is not done for kernel 3 or older.   

Any better solution, please post a comment I'll fix that.  

P.S. We have host with old comment and necessity to have our driver there, that's why I made this fix  